### PR TITLE
Use IsUnlocked not FacilityLevel for Surface Samples

### DIFF
--- a/KEI/KEI.cs
+++ b/KEI/KEI.cs
@@ -233,7 +233,7 @@ namespace KEI
 
             // Don't check RnD level to determine if surface samples are available, in case another mod messes with the Facility Levels.
             //Instead just check the experiment is available directly.
-            if (SResearchAndDevelopment.GetExperiment("surfaceSample").IsUnlocked())
+            if (ResearchAndDevelopment.GetExperiment("surfaceSample").IsUnlocked())
                 unlockedExperiments.Add(ResearchAndDevelopment.GetExperiment("surfaceSample"));
 
             foreach

--- a/KEI/KEI.cs
+++ b/KEI/KEI.cs
@@ -231,9 +231,9 @@ namespace KEI
             // EVA Reports available from the beginning
             unlockedExperiments.Add(ResearchAndDevelopment.GetExperiment("evaReport"));
 
-            // To take surface samples from other worlds you need to upgrade Astronaut Complex and R&D
-            // But to take surface samples from home you need to only upgrade R&D
-            if (ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.ResearchAndDevelopment) > 0.0)
+            // Don't check RnD level to determine if surface samples are available, in case another mod messes with the Facility Levels.
+            //Instead just check the experiment is available directly.
+            if (SResearchAndDevelopment.GetExperiment("surfaceSample").IsUnlocked())
                 unlockedExperiments.Add(ResearchAndDevelopment.GetExperiment("surfaceSample"));
 
             foreach


### PR DESCRIPTION
Checking RnD for surface sample availability only works if the facility upgrade levels don't get changed (via CustomBarnKit etc).

Much better to check it using IsUnlocked instead. (This fixes an incompatibility between KEI and Bureaucracy due to the above reason)